### PR TITLE
chore: update llm-reasoners dependency path in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ azure-identity
 openai
 requests
 python-dotenv
--e ./llm-reasoning-api/api/algorithms/llm-reasoners
+git+https://github.com/ajaye2/llm-reasoners


### PR DESCRIPTION
- Replaced the local path for llm-reasoners with a GitHub repository link for better accessibility and version control.