### PR TITLE
feat: enhance deployment workflow by adding reasoners module copy step

### DIFF
--- a/.github/workflows/main_llm-reasoning-api.yml
+++ b/.github/workflows/main_llm-reasoning-api.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Prepare deployment artifact
         run: |
           mkdir deployment
+
           # Copy the api/ directory
           if [ -d "llm-reasoning-api/api" ]; then
             cp -R llm-reasoning-api/api/ deployment/
@@ -51,6 +52,15 @@ jobs:
             echo "ERROR: api/ directory not found!"
             exit 1
           fi
+
+          # Copy the reasoners module
+          if [ -d "llm-reasoning-api/api/algorithms/llm-reasoners/reasoners" ]; then
+            cp -R llm-reasoning-api/api/algorithms/llm-reasoners/reasoners/ deployment/reasoners/
+          else
+            echo "ERROR: reasoners/ directory not found!"
+            exit 1
+          fi
+
           cp requirements.txt deployment/
           cp setup_dependencies.sh deployment/
           cd deployment && zip -r ../release.zip .


### PR DESCRIPTION
- Added a step to copy the reasoners module from the llm-reasoning-api to the deployment artifact.
- Included error handling to check for the existence of the reasoners directory before copying.
- Ensured the deployment process is more robust by verifying the presence of necessary directories.